### PR TITLE
Allow for preserving query params across redirects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     mysql2 (0.3.11)
     nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
+    pg (0.17.0)
     polyglot (0.3.3)
     rack (1.4.1)
     rack-cache (1.2)
@@ -134,6 +135,7 @@ DEPENDENCIES
   factory_girl_rails (~> 1.7)
   jquery-rails
   mysql2
+  pg
   redirector!
   rspec-rails
   shoulda-matchers

--- a/lib/redirector.rb
+++ b/lib/redirector.rb
@@ -3,6 +3,7 @@ module Redirector
   autoload :RegexAttribute, 'redirector/regex_attribute'
 
   mattr_accessor :include_query_in_source
+  mattr_accessor :preserve_query
   mattr_accessor :silence_sql_logs
 
   def self.active_record_protected_attributes?

--- a/lib/redirector/engine.rb
+++ b/lib/redirector/engine.rb
@@ -8,6 +8,7 @@ module Redirector
 
     initializer "redirector.apply_options" do |app|
       Redirector.include_query_in_source = app.config.redirector.include_query_in_source || false
+      Redirector.preserve_query          = app.config.redirector.preserve_query || false
       Redirector.silence_sql_logs        = app.config.redirector.silence_sql_logs || false
     end
   end

--- a/lib/redirector/middleware.rb
+++ b/lib/redirector/middleware.rb
@@ -83,6 +83,7 @@ module Redirector
           uri.scheme ||= 'http'
           uri.host   ||= request_host
           uri.port   ||= request_port if request_port.present?
+          uri.query  ||= env['QUERY_STRING'] if Redirector.preserve_query
         end
       end
 

--- a/redirector.gemspec
+++ b/redirector.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   # s.add_dependency "jquery-rails"
 
   s.add_development_dependency "mysql2"
+  s.add_development_dependency "pg"
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'capybara', '~> 2.2'

--- a/spec/features/middleware_spec.rb
+++ b/spec/features/middleware_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Redirector middleware' do
+describe 'Redirector middleware', :type => :feature do
   before do
     FactoryGirl.create(:redirect_rule, :destination => '/news/5', :source => '/my_custom_url')
     FactoryGirl.create(:redirect_rule_regex, :destination => '/news/$1', :source => '/my_custom_url/([A-Za-z0-9_]+)')
@@ -28,6 +28,16 @@ describe 'Redirector middleware' do
     visit '/my_old_url?categoryID=12345'
     current_path.should == '/news'
     Redirector.include_query_in_source = original_option
+  end
+
+  it 'should preserve the query string if the Redirector.preserve_query is true' do
+    original_option = Redirector.preserve_query
+    Redirector.preserve_query = true
+    visit '/my_custom_url/20?categoryID=12345'
+    uri = URI.parse(current_url)
+    uri.query.should == 'categoryID=12345'
+    current_path.should == '/news/20'
+    Redirector.preserve_query = original_option
   end
 
   it 'handles requests with or without a port specified' do


### PR DESCRIPTION
Enables an option to preserve the query string across redirects. Defaulted to false (original behavior).
