### PR TITLE
Adds stripping of RedirectRule.source value with 'before_save' callback.

### DIFF
--- a/app/models/redirect_rule.rb
+++ b/app/models/redirect_rule.rb
@@ -16,6 +16,8 @@ class RedirectRule < ActiveRecord::Base
   validates :source, :destination, :presence => true
   validates :active, :inclusion => { :in => ['0', '1', true, false] }
 
+  before_save :strip_source_whitespace
+
   def self.regex_expression
     if connection_mysql?
       '(redirect_rules.source_is_case_sensitive = :true AND :source REGEXP BINARY redirect_rules.source) OR '+
@@ -70,6 +72,10 @@ class RedirectRule < ActiveRecord::Base
 
   def self.connection_mysql?
     connection.adapter_name.downcase.include?('mysql')
+  end
+
+  def strip_source_whitespace
+    self.source = self.source.strip
   end
 
 end

--- a/spec/models/redirect_rule_spec.rb
+++ b/spec/models/redirect_rule_spec.rb
@@ -32,6 +32,15 @@ describe RedirectRule do
     new_rule.errors_on(:source).should == ['is an invalid regular expression']
   end
 
+  describe 'strip_source_whitespace before_save callback' do
+    it 'strips leading and trailing whitespace when saved' do
+      subject = FactoryGirl.build(:redirect_rule, :source => ' /needs-stripping ')
+
+      subject.save
+      subject.reload.source.should == '/needs-stripping'
+    end
+  end
+
   describe '.match_for' do
     it 'returns nil if there is no matching rule' do
       RedirectRule.match_for('/someplace', {}).should be_nil


### PR DESCRIPTION
Recently a client was creating a lot of redirects for transitioning between their existing site and their new site. They somehow included trailing spaces in the source field on a number of them which was causing request matching to fail.

If there is a better solution, please let me know and disregard this PR.

:lollipop: 
