### PR TITLE
Ignored patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Redirector is a Rails engine that adds a piece of middleware to the top of your 
 
 `preserve_query`: Pass the query string parameters through from the source to the target URL.
 
+`ignored_patterns`: Lets you define an array of regex patterns which will be ignored when searching for redirect records. ie: `[/^\/assets\/.+/]` will bypass a database lookup for any path that starts with `/assets/`. This can be useful in preventing numerous unnecessary lookups.
+
 You can set these inside your configuration in `config/application.rb` of your Rails application like so:
 
 ```ruby
@@ -35,6 +37,7 @@ module MyApplication
 
     config.redirector.include_query_in_source = true
     config.redirector.silence_sql_logs = true
+    config.redirector.ignored_patterns = [/^\/assets\/.+/]
   end
 end
 ```

--- a/lib/redirector.rb
+++ b/lib/redirector.rb
@@ -5,6 +5,7 @@ module Redirector
   mattr_accessor :include_query_in_source
   mattr_accessor :preserve_query
   mattr_accessor :silence_sql_logs
+  mattr_accessor :ignored_patterns
 
   def self.active_record_protected_attributes?
     @active_record_protected_attributes ||= Rails.version.to_i < 4 || defined?(ProtectedAttributes)

--- a/lib/redirector/engine.rb
+++ b/lib/redirector/engine.rb
@@ -10,6 +10,7 @@ module Redirector
       Redirector.include_query_in_source = app.config.redirector.include_query_in_source || false
       Redirector.preserve_query          = app.config.redirector.preserve_query || false
       Redirector.silence_sql_logs        = app.config.redirector.silence_sql_logs || false
+      Redirector.ignored_patterns        = app.config.redirector.ignored_patterns || []
     end
   end
 end

--- a/lib/redirector/middleware.rb
+++ b/lib/redirector/middleware.rb
@@ -29,7 +29,7 @@ module Redirector
       private
 
       def redirect?
-        matched_destination.present?
+        !ignore_path? && matched_destination.present?
       end
 
       def matched_destination
@@ -46,8 +46,14 @@ module Redirector
         end
       end
 
+      def ignore_path?
+        Redirector.ignored_patterns.any? do |pattern|
+          request_path.match pattern
+        end
+      end
+
       def request_path
-        if Redirector.include_query_in_source
+        @request_path ||= if Redirector.include_query_in_source
           env['ORIGINAL_FULLPATH']
         else
           env['PATH_INFO']

--- a/spec/features/middleware_spec.rb
+++ b/spec/features/middleware_spec.rb
@@ -60,6 +60,16 @@ describe 'Redirector middleware', :type => :feature do
     current_url.should == 'http://example.com:3000/news/5'
   end
 
+  it 'foregoes search if ignored path pattern is detected' do
+    original_option = Redirector.ignored_patterns
+    Redirector.ignored_patterns = [/^\/my_custom_url\/.+/]
+
+    visit '/my_custom_url/20'
+    current_path.should == '/my_custom_url/20'
+
+    Redirector.ignored_patterns = original_option
+  end
+
   unless Rails.version =~ /\A4\.2\.\d\z/
     it 'handles invalid URIs properly' do
       bad_rule = create(:redirect_rule_regex, :destination => 'http://www.example.com$1', :source => '^/custom(.*)$')


### PR DESCRIPTION
Many active admin pages on a recent project load in record slow times, part of the reason is that there are approximately 7 million db queries checking for redirect rules on every single `/assets/admin/...` request. This PR adds a config option which allows for setting an `ignored_patterns` array which can be used to skip the db lookup for a given regex pattern.