### PR TITLE
Strip whitespace from destination too

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redirector (1.1.2)
+    redirector (1.1.4)
       rails (>= 3.1)
 
 GEM
@@ -77,7 +77,7 @@ GEM
     factory_bot_rails (4.8.2)
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -89,14 +89,14 @@ GEM
     loofah (2.2.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     mysql2 (0.4.10)
-    nio4r (2.3.1)
+    nio4r (2.5.2)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pg (1.0.0)
@@ -155,7 +155,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -172,7 +172,7 @@ GEM
       thread_safe (~> 0.1)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.4)
     xpath (3.0.0)
       nokogiri (~> 1.8)
 
@@ -196,4 +196,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/app/models/redirect_rule.rb
+++ b/app/models/redirect_rule.rb
@@ -20,7 +20,7 @@ class RedirectRule < ActiveRecord::Base
     validates :active, :inclusion => { :in => ['0', '1', true, false] }
   end
 
-  before_save :strip_source_whitespace
+  before_save :strip_source_whitespace, :strip_destination_whitespace
 
   def self.regex_expression
     if connection_mysql?
@@ -87,6 +87,10 @@ class RedirectRule < ActiveRecord::Base
 
   def strip_source_whitespace
     self.source = self.source.strip
+  end
+
+  def strip_destination_whitespace
+    self.destination = self.destination.strip
   end
 
 end

--- a/spec/models/redirect_rule_spec.rb
+++ b/spec/models/redirect_rule_spec.rb
@@ -46,6 +46,15 @@ describe RedirectRule do
     end
   end
 
+  describe 'strip_destination_whitespace before_save callback' do
+    it 'strips leading and trailing whitespace when saved' do
+      subject = build(:redirect_rule, :destination => ' /needs-stripping ')
+
+      subject.save
+      expect(subject.reload.destination).to eq('/needs-stripping')
+    end
+  end
+
   describe '.match_for' do
     it 'returns nil if there is no matching rule' do
       expect(RedirectRule.match_for('/someplace', {})).to be_nil


### PR DESCRIPTION
Allowing users to enter rules with whitespace between the destination URL will result in exceptions when we get to `URI.parse(matched_destination)` in `middleware.rb`.

This will at least take a step toward it being more foolproof, but thoughts on adding a validation for URI validity?